### PR TITLE
Add error messages, disable buttons while loading

### DIFF
--- a/src/blink_client/src/App.tsx
+++ b/src/blink_client/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-black">
-      <SwapCard identity={identity} handleConnect={handleConnect} />
+      WIP
     </div>
   );
 }

--- a/src/blink_client/src/components/ui/ErrorMessage.tsx
+++ b/src/blink_client/src/components/ui/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+export const ErrorMessage = ({
+  error,
+  setError,
+  className,
+}: {
+  error: any;
+  setError: (error: any) => void;
+  className?: string;
+}) => {
+  if (!error) return null;
+  return (
+    <div
+      className={
+        "w-full border-2 rounded-sm p-4 mt-1 border-red-500 text-red-500 text-wrap relative " +
+        className
+      }
+      onClick={() => setError(null)}
+    >
+      <button className="absolute right-1 top-1 border-[1px] border-gray-500 text-gray-500 w-[1.6em] h-[1.6em] text-center text-sm rounded-full">
+        x
+      </button>
+      {error}
+    </div>
+  );
+};

--- a/src/blink_client/src/components/ui/buttons/ConnectWalletButton.tsx
+++ b/src/blink_client/src/components/ui/buttons/ConnectWalletButton.tsx
@@ -3,12 +3,15 @@ import stoicWalletLogo from "../../../assets/stoic-wallet-logo.png";
 
 const ConnectWalletButton = ({
   handleConnect,
+  disabled,
 }: {
   handleConnect: () => void;
+  disabled: boolean;
 }) => (
   <button
-    className="w-full text-stone-900 font-medium rounded-full text-center p-2 m-2 bg-gradient-to-r from-lime-300 to-green-500 transition ease-in delay-100 hover:-translate-y-1 hover:scale-105 hover:bg-indigo-500 duration-150"
+    className="w-full text-stone-900 font-medium rounded-full text-center p-2 m-2 bg-gradient-to-r from-lime-300 to-green-500 transition ease-in delay-100 hover:-translate-y-1 hover:scale-105 hover:bg-indigo-500 duration-150 disabled:opacity-50 disabled:scale-100 disabled:-translate-y-0"
     onClick={() => handleConnect()}
+    disabled={disabled}
   >
     <span className="inline-flex items-center">
       <img

--- a/src/blink_client/src/pages/SwapPage.tsx
+++ b/src/blink_client/src/pages/SwapPage.tsx
@@ -48,7 +48,7 @@ function SwapPage() {
 
   const handleSwap = async (amount: number) => {
     if (!identity) {
-      return;
+      throw "Wallet is not connected";
     }
     console.log("Swapping token");
     const httpAgent = new HttpAgent({


### PR DESCRIPTION
I added some basic error messages and disabled the buttons while actions are pending.
Also added some `disabled:*` tailwind classes to give visual feedback.

Success cases should also give some feedback (not implemented).
For now I added a simple alert() to confirm a successful claim action, but this should probably be replaced by a toast message or something alike.